### PR TITLE
Add a test case for `MyOption`

### DIFF
--- a/src/test/scala/com/chatwork/quiz/MyOptionSpec.scala
+++ b/src/test/scala/com/chatwork/quiz/MyOptionSpec.scala
@@ -5,6 +5,12 @@ import org.scalatest.matchers.should.Matchers
 
 class MyOptionSpec extends AnyFunSpec with Matchers {
 
+  describe("MyOption#apply") {
+    it("should return MyNone if it's null") {
+      MyOption(null) shouldBe MyNone
+    }
+  }
+
   describe("MyOption#get") {
     it("should return a value if it's not empty") {
       MySome(100).get shouldBe 100


### PR DESCRIPTION
For the welfare of humanity, the original implementation returns `None`.

```
scala> Option(null)
val res0: Option[Null] = None

scala> Some.apply(null)
val res1: Some[Null] = Some(null)
```